### PR TITLE
chore: add badges to README and gemspec metadata to fix rubygems links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # RspecProfiling
 
+[![Test](https://github.com/procore-oss/rspec_profiling/actions/workflows/test.yaml/badge.svg?branch=main)](https://github.com/procore-oss/rspec_profiling/actions/workflows/test.yaml)
+[![Gem Version](https://badge.fury.io/rb/rspec_profiling.svg)](https://badge.fury.io/rb/rspec_profiling)
+[![Discord](https://img.shields.io/badge/Chat-EDEDED?logo=discord)](https://discord.gg/PbntEMmWws) 
+
+
 Collects profiles of RSpec test suites, enabling you to identify specs
 with interesting attributes. For example, find the slowest specs, or the
 spec which issues the most queries.

--- a/rspec_profiling.gemspec
+++ b/rspec_profiling.gemspec
@@ -29,4 +29,6 @@ Gem::Specification.new do |spec|
 
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
   spec.metadata['rubygems_mfa_required'] = 'true'
+  spec.metadata['homepage_uri'] = spec.homepage
+  spec.metadata['source_code_uri'] = spec.homepage
 end


### PR DESCRIPTION
Seems the homepage and stars links on https://rubygems.org/gems/rspec_profiling still link to github.com/foraker/rspec_profiling (old parent repo).  Hopefully these metadata entries will fix that

Also added test results, rubygems and discord badges to README

Checklist:

* [x] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://github.com/procore-oss/rspec_profiling/blob/main/CONTRIBUTING.md)
* [x] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

TL;DR - You need to sign off your commits with `git commit -s` or `git commit --signoff` to indicate that you agree to the terms of the DCO.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
