### PR TITLE
feat: implement magic comment fetching for ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ end
 - `table_name` - the database table name in which results are stored
 - `csv_path` - the directory in which CSV files are dumped
 - `collector` - collector to use
-- `magic_comment` - comment to scan top of files for to enable ownership tracking (EX: `#team: tooling`)
+- `magic_comment` - comment to scan top of files to enable ownership tracking (EX: `#team: tooling`)
 
 ### Usage in a script
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ end
 
 #### Custom Ownership Tracking
 
-If the repo you are running the profiler on has many teams working on it, you can use the `magic_comment` option to specify a comment to scan the top of files for to enable ownership tracking. In the example below,
+If the repo you are running the profiler on has many teams working on it, you can use the `magic_comment` option to specify a comment at the top of files to scan for ownership tracking.  In the example below,
 the profiler will look for `#team: <owner>` comments at the top of each file and add <owner> to the results.
 The default is `team` but can be configured to any comment you want.
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,18 @@ RspecProfiling.configure do |config|
 end
 ```
 
+#### Custom Ownership Tracking
+
+If the repo you are running the profiler on has many teams working on it, you can use the `magic_comment` option to specify a comment to scan the top of files for to enable ownership tracking. In the example below,
+the profiler will look for `#team: <owner>` comments at the top of each file and add <owner> to the results.
+The default is `team` but can be configured to any comment you want.
+
+```Ruby
+RspecProfiling.configure do |config|
+  config.magic_comment = 'team'
+end
+```
+
 #### Custom Event Subscriptions
 
 ```Ruby
@@ -204,6 +216,7 @@ end
 - `table_name` - the database table name in which results are stored
 - `csv_path` - the directory in which CSV files are dumped
 - `collector` - collector to use
+- `magic_comment` - comment to scan top of files for to enable ownership tracking (EX: `#team: tooling`)
 
 ### Usage in a script
 

--- a/lib/rspec_profiling/collectors/csv.rb
+++ b/lib/rspec_profiling/collectors/csv.rb
@@ -10,6 +10,7 @@ module RspecProfiling
         date
         file
         line_number
+        owner_tag
         description
         status
         exception

--- a/lib/rspec_profiling/collectors/json.rb
+++ b/lib/rspec_profiling/collectors/json.rb
@@ -8,6 +8,7 @@ module RspecProfiling
         date
         file
         line_number
+        owner_tag
         description
         status
         exception

--- a/lib/rspec_profiling/config.rb
+++ b/lib/rspec_profiling/config.rb
@@ -9,7 +9,7 @@ module RspecProfiling
       vcs:        RspecProfiling::VCS::Git,
       table_name: 'spec_profiling_results',
       events:     [],
-      magic_comment: '',
+      magic_comment: 'team',
       additional_data: {}
     })
   end

--- a/lib/rspec_profiling/config.rb
+++ b/lib/rspec_profiling/config.rb
@@ -9,6 +9,7 @@ module RspecProfiling
       vcs:        RspecProfiling::VCS::Git,
       table_name: 'spec_profiling_results',
       events:     [],
+      magic_comment: '',
       additional_data: {}
     })
   end

--- a/lib/rspec_profiling/example.rb
+++ b/lib/rspec_profiling/example.rb
@@ -128,10 +128,10 @@ module RspecProfiling
       ownership_regex = /(^#\s*#{RspecProfiling.config.magic_comment}:\s*)\K(?<#{RspecProfiling.config.magic_comment}>.*$)/.freeze
       comments = top_comments_from_file(file_path)
       puts "Comments: #{comments}"
-      puts "REGEX: #{OWNERSHIP_REGEX}"
-      matching_line = comments.detect { |line| line.match?(OWNERSHIP_REGEX) }
+      puts "REGEX: #{ownership_regex}"
+      matching_line = comments.detect { |line| line.match?(ownership_regex) }
       puts "Matching line: #{matching_line}"
-      extract_ownership(matching_line, OWNERSHIP_REGEX) if matching_line
+      extract_ownership(matching_line, ownership_regex) if matching_line
     end
 
     def top_comments_from_file(file_path)

--- a/lib/rspec_profiling/example.rb
+++ b/lib/rspec_profiling/example.rb
@@ -139,10 +139,10 @@ module RspecProfiling
     end
 
     def with_file(file_path)
-      if File.exist?(file_or_path)
-        File.open(file_or_path)
+      if File.exist?(file_path)
+        File.open(file_path)
       else
-        puts "File not found: #{file_or_path}"
+        puts "File not found: #{file_path}"
         []
       end
     end

--- a/lib/rspec_profiling/example.rb
+++ b/lib/rspec_profiling/example.rb
@@ -106,7 +106,7 @@ module RspecProfiling
 
     attr_reader :example, :counts
 
-    OWNERSHIP_REGEX = /(^#\s*#{RspecProfiling.config.magic_comment}:\s*)\K(?<#{RspecProfiling.config.magic_comment}>.*$)/
+    OWNERSHIP_REGEX = /(^#\s*#{RspecProfiling.config.magic_comment}:\s*)\K(?<#{RspecProfiling.config.magic_comment}>.*$)/.freeze
 
     def execution_result
       @execution_result ||= begin
@@ -126,7 +126,7 @@ module RspecProfiling
 
     def ownership_for_file(file_path)
       return nil if RspecProfiling.config.magic_comment.empty?
-
+      puts "Magic comment: #{RspecProfiling.config.magic_comment}"
       comments = top_comments_from_file(file_path)
       matching_line = comments.detect { |line| line.match?(OWNERSHIP_REGEX) }
       extract_ownership(matching_line) if matching_line

--- a/lib/rspec_profiling/example.rb
+++ b/lib/rspec_profiling/example.rb
@@ -106,8 +106,6 @@ module RspecProfiling
 
     attr_reader :example, :counts
 
-    OWNERSHIP_REGEX = /(^#\s*#{RspecProfiling.config.magic_comment}:\s*)\K(?<#{RspecProfiling.config.magic_comment}>.*$)/.freeze
-
     def execution_result
       @execution_result ||= begin
         result = example.execution_result
@@ -127,12 +125,13 @@ module RspecProfiling
     def ownership_for_file(file_path)
       return nil if RspecProfiling.config.magic_comment.empty?
       puts "Magic comment: #{RspecProfiling.config.magic_comment}"
+      OWNERSHIP_REGEX = /(^#\s*#{RspecProfiling.config.magic_comment}:\s*)\K(?<#{RspecProfiling.config.magic_comment}>.*$)/.freeze
       comments = top_comments_from_file(file_path)
       puts "Comments: #{comments}"
       puts "REGEX: #{OWNERSHIP_REGEX}"
       matching_line = comments.detect { |line| line.match?(OWNERSHIP_REGEX) }
       puts "Matching line: #{matching_line}"
-      extract_ownership(matching_line) if matching_line
+      extract_ownership(matching_line, OWNERSHIP_REGEX) if matching_line
     end
 
     def top_comments_from_file(file_path)
@@ -150,8 +149,8 @@ module RspecProfiling
       end
     end
 
-    def extract_ownership(matching_line)
-      matching_line.match(OWNERSHIP_REGEX)[RspecProfiling.config.magic_comment.to_sym]
+    def extract_ownership(matching_line, regex)
+      matching_line.match(regex)[RspecProfiling.config.magic_comment.to_sym]
     end
   end
 end

--- a/lib/rspec_profiling/example.rb
+++ b/lib/rspec_profiling/example.rb
@@ -125,7 +125,7 @@ module RspecProfiling
     def ownership_for_file(file_path)
       return nil if RspecProfiling.config.magic_comment.empty?
       puts "Magic comment: #{RspecProfiling.config.magic_comment}"
-      OWNERSHIP_REGEX = /(^#\s*#{RspecProfiling.config.magic_comment}:\s*)\K(?<#{RspecProfiling.config.magic_comment}>.*$)/.freeze
+      ownership_regex = /(^#\s*#{RspecProfiling.config.magic_comment}:\s*)\K(?<#{RspecProfiling.config.magic_comment}>.*$)/.freeze
       comments = top_comments_from_file(file_path)
       puts "Comments: #{comments}"
       puts "REGEX: #{OWNERSHIP_REGEX}"

--- a/lib/rspec_profiling/example.rb
+++ b/lib/rspec_profiling/example.rb
@@ -124,13 +124,9 @@ module RspecProfiling
 
     def ownership_for_file(file_path)
       return nil if RspecProfiling.config.magic_comment.empty?
-      puts "Magic comment: #{RspecProfiling.config.magic_comment}"
       ownership_regex = /(^#\s*#{RspecProfiling.config.magic_comment}:\s*)\K(?<#{RspecProfiling.config.magic_comment}>.*$)/.freeze
       comments = top_comments_from_file(file_path)
-      puts "Comments: #{comments}"
-      puts "REGEX: #{ownership_regex}"
       matching_line = comments.detect { |line| line.match?(ownership_regex) }
-      puts "Matching line: #{matching_line}"
       extract_ownership(matching_line, ownership_regex) if matching_line
     end
 

--- a/lib/rspec_profiling/example.rb
+++ b/lib/rspec_profiling/example.rb
@@ -128,7 +128,10 @@ module RspecProfiling
       return nil if RspecProfiling.config.magic_comment.empty?
       puts "Magic comment: #{RspecProfiling.config.magic_comment}"
       comments = top_comments_from_file(file_path)
+      puts "Comments: #{comments}"
+      puts "REGEX: #{OWNERSHIP_REGEX}"
       matching_line = comments.detect { |line| line.match?(OWNERSHIP_REGEX) }
+      puts "Matching line: #{matching_line}"
       extract_ownership(matching_line) if matching_line
     end
 

--- a/lib/rspec_profiling/run.rb
+++ b/lib/rspec_profiling/run.rb
@@ -42,6 +42,7 @@ module RspecProfiling
         status:        @current_example.status,
         exception:     @current_example.exception,
         time:          @current_example.time,
+        owner_tag:     @current_example.owner_tag,
         query_count:   @current_example.query_count,
         query_time:    @current_example.query_time,
         request_count: @current_example.request_count,

--- a/spec/run_spec.rb
+++ b/spec/run_spec.rb
@@ -35,6 +35,7 @@ module RspecProfiling
           record_events: %w[custom]
         })
       end
+      let(:file_with_team) { StringIO.new("# frozen_string_literal: true\n# team: apples\n# Bogus comment\nnot a comment\n") }
 
       def simulate_test_suite_run
         run.start
@@ -48,6 +49,8 @@ module RspecProfiling
       end
 
       before do
+        allow(File).to receive(:exist?).and_return(true)
+        allow(File).to receive(:open).and_return(file_with_team)
         stub_const("ActiveSupport::Notifications", Notifications.new)
         simulate_test_suite_run
       end
@@ -106,6 +109,10 @@ module RspecProfiling
 
       it "records the custom event events" do
         expect(result.event_events["custom"]).to eq [{"data"=>{"key"=>"value"}, "name"=>"custom"}]
+      end
+
+      it "records the magic comment" do
+        expect(result.owner_tag).to eq "apples"
       end
     end
 

--- a/spec/run_spec.rb
+++ b/spec/run_spec.rb
@@ -111,7 +111,7 @@ module RspecProfiling
         expect(result.event_events["custom"]).to eq [{"data"=>{"key"=>"value"}, "name"=>"custom"}]
       end
 
-      it "records the magic comment" do
+      it "records the owner comment" do
         expect(result.owner_tag).to eq "apples"
       end
     end


### PR DESCRIPTION
Implementation of https://github.com/procore-oss/rspec_profiling/issues/8

This feature allows a magic comment to be defined that the profiler will check the top of the spec files for and attribute ownership for each spec. This defaults to `team` but can be configured to any comment youd like. Documentation has been updated.

Testing:
- Unit tested the happy path

- Tested in CI with magic comment matching pattern already used and with pattern not matching anything. Correctly attributed each test with either the correct ownership or `nil` if nothing matched.

Checklist:

* [x] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://github.com/procore-oss/rspec_profiling/blob/main/CONTRIBUTING.md)
* [x] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

TL;DR - You need to sign off your commits with `git commit -s` or `git commit --signoff` to indicate that you agree to the terms of the DCO.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
