### PR TITLE
chore: drop ruby 2.7 support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,11 +17,12 @@ jobs:
       SPEC_GEMFILE: spec/Gemfile
     strategy:
       matrix:
-        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3']
+        os: [ubuntu-latest]
+        ruby: ['3.0', '3.1', '3.2', '3.3']
         postgres: ['16-bookworm', '15-bookworm', '14-bookworm', '13-bookworm', '12-bookworm']
     name: Ruby ${{ matrix.ruby }} - PostgreSQL ${{ matrix.postgres }}
     # https://docs.github.com/en/actions/learn-github-actions/expressions#example
-    runs-on: ${{ matrix.ruby == '2.7' && 'ubuntu-20.04' || 'ubuntu-latest' }}
+    runs-on: ${{ matrix.os }}
     services:
       postgres:
         image: postgres:${{ matrix.postgres }}

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,7 @@ Ruby versions that are currently being supported with security updates.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| <=2.6   | :x:                |
-| 2.7     | :white_check_mark: |
+| <=2.7   | :x:                |
 | 3.0     | :white_check_mark: |
 | 3.1     | :white_check_mark: |
 | 3.2     | :white_check_mark: |

--- a/rspec_profiling.gemspec
+++ b/rspec_profiling.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |spec|
   spec.summary       = %q{Profile RSpec test suites}
   spec.homepage      = "https://github.com/procore-oss/rspec_profiling"
   spec.license       = "MIT"
+  spec.required_ruby_version = Gem::Requirement.new('>= 3.0')
 
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }


### PR DESCRIPTION
- [x] update all related files for new ruby version minimum (3.0)

Checklist:

* [x] I have updated the necessary documentation
* [x] I have signed off all my commits as required by [DCO](https://github.com/procore-oss/rspec_profiling/blob/main/CONTRIBUTING.md)
* [x] My build is green

<!--
Note on DCO:

If the DCO check fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.

TL;DR - You need to sign off your commits with `git commit -s` or `git commit --signoff` to indicate that you agree to the terms of the DCO.

Note on Versioning:

Maintainers will bump the version and do a release when they are ready to release (possibly multiple merged PRs). Please do not bump the version in your PRs.
-->
